### PR TITLE
feat: 장바구니에서 상품을 주문할 수 있다. #13

### DIFF
--- a/src/main/java/com/woowa/woowakit/domain/auth/domain/Member.java
+++ b/src/main/java/com/woowa/woowakit/domain/auth/domain/Member.java
@@ -4,6 +4,7 @@ import com.woowa.woowakit.domain.auth.domain.converter.EmailConverter;
 import com.woowa.woowakit.domain.auth.domain.converter.PasswordConverter;
 import com.woowa.woowakit.domain.auth.exception.LoginFailException;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,6 +34,7 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Builder
     private Member(
             final Email email,
             final EncodedPassword encodedPassword,

--- a/src/main/java/com/woowa/woowakit/domain/cart/domain/CartItemRepository.java
+++ b/src/main/java/com/woowa/woowakit/domain/cart/domain/CartItemRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,9 +13,20 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 	Optional<CartItem> findCartItemByMemberIdAndProductId(Long memberId, Long productId);
 
 	@Query(
-		" select new com.woowa.woowakit.domain.cart.domain.CartItemSpecification(c.quantity , p.price,p.name, p.imageUrl,p.id)"
+		" select new com.woowa.woowakit.domain.cart.domain.CartItemSpecification(c.quantity, p.price, p.name, p.imageUrl, p.id)"
 			+ "  from CartItem c"
 			+ "  join Product p on p.id = c.productId "
 			+ "  where c.memberId = :memberId")
 	List<CartItemSpecification> findCartItemByMemberId(@Param("memberId") Long memberId);
+
+	@Query(
+		"select new com.woowa.woowakit.domain.cart.domain.CartItemSpecification(c.quantity, p.price, p.name, p.imageUrl, p.id)"
+			+ " from CartItem c "
+			+ " join Product p on p.id = c.productId "
+			+ " where c.memberId = :memberId and c.id = :id")
+	Optional<CartItemSpecification> findCartItemByIdAndMemberId(@Param("memberId") Long memberId, @Param("id") Long id);
+
+	@Modifying
+	@Query("delete from CartItem c where c.productId in :productIds and c.memberId = :memberId")
+	void deleteAllByProductIdAndMemberId(@Param("memberId") Long memberId, @Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/woowa/woowakit/domain/order/api/OrderController.java
+++ b/src/main/java/com/woowa/woowakit/domain/order/api/OrderController.java
@@ -18,6 +18,7 @@ import com.woowa.woowakit.domain.auth.annotation.User;
 import com.woowa.woowakit.domain.auth.domain.AuthPrincipal;
 import com.woowa.woowakit.domain.order.application.OrderService;
 import com.woowa.woowakit.domain.order.dto.request.OrderCreateRequest;
+import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateCartItemRequest;
 import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateRequest;
 import com.woowa.woowakit.domain.order.dto.response.OrderDetailResponse;
 import com.woowa.woowakit.domain.order.dto.response.PreOrderResponse;
@@ -39,6 +40,16 @@ public class OrderController {
         @Valid @RequestBody final PreOrderCreateRequest request
     ) {
         PreOrderResponse preOrderResponse = orderService.preOrder(authPrincipal, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(preOrderResponse);
+    }
+
+    @PostMapping("/pre-cart-item")
+    @User
+    public ResponseEntity<PreOrderResponse> createPreOrderByCartItems(
+        @Authenticated final AuthPrincipal authPrincipal,
+        @Valid @RequestBody final List<PreOrderCreateCartItemRequest> requests
+    ) {
+        PreOrderResponse preOrderResponse = orderService.preOrderCartItems(authPrincipal, requests);
         return ResponseEntity.status(HttpStatus.CREATED).body(preOrderResponse);
     }
 

--- a/src/main/java/com/woowa/woowakit/domain/order/application/OrderService.java
+++ b/src/main/java/com/woowa/woowakit/domain/order/application/OrderService.java
@@ -53,7 +53,7 @@ public class OrderService {
 		final AuthPrincipal authPrincipal,
 		final List<PreOrderCreateCartItemRequest> requests
 	) {
-		List<Long> cartItemIds = PreOrderCreateCartItemRequest.listOf(requests);
+		List<Long> cartItemIds = PreOrderCreateCartItemRequest.toCartItemIds(requests);
 		Order order = orderMapper.mapFrom(authPrincipal.getId(), cartItemIds);
 		return PreOrderResponse.from(orderRepository.save(order));
 	}

--- a/src/main/java/com/woowa/woowakit/domain/order/application/OrderService.java
+++ b/src/main/java/com/woowa/woowakit/domain/order/application/OrderService.java
@@ -10,6 +10,7 @@ import com.woowa.woowakit.domain.order.domain.Order;
 import com.woowa.woowakit.domain.order.domain.OrderMapper;
 import com.woowa.woowakit.domain.order.domain.OrderRepository;
 import com.woowa.woowakit.domain.order.dto.request.OrderCreateRequest;
+import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateCartItemRequest;
 import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateRequest;
 import com.woowa.woowakit.domain.order.dto.response.OrderDetailResponse;
 import com.woowa.woowakit.domain.order.dto.response.PreOrderResponse;
@@ -44,6 +45,16 @@ public class OrderService {
 	@Transactional
 	public PreOrderResponse preOrder(final AuthPrincipal authPrincipal, final PreOrderCreateRequest request) {
 		Order order = orderMapper.mapFrom(authPrincipal.getId(), request.getProductId(), request.getQuantity());
+		return PreOrderResponse.from(orderRepository.save(order));
+	}
+
+	@Transactional
+	public PreOrderResponse preOrderCartItems(
+		final AuthPrincipal authPrincipal,
+		final List<PreOrderCreateCartItemRequest> requests
+	) {
+		List<Long> cartItemIds = PreOrderCreateCartItemRequest.listOf(requests);
+		Order order = orderMapper.mapFrom(authPrincipal.getId(), cartItemIds);
 		return PreOrderResponse.from(orderRepository.save(order));
 	}
 

--- a/src/main/java/com/woowa/woowakit/domain/order/domain/handler/CartItemDeleteEventHandler.java
+++ b/src/main/java/com/woowa/woowakit/domain/order/domain/handler/CartItemDeleteEventHandler.java
@@ -1,0 +1,37 @@
+package com.woowa.woowakit.domain.order.domain.handler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.woowa.woowakit.domain.cart.domain.CartItemRepository;
+import com.woowa.woowakit.domain.order.domain.OrderItem;
+import com.woowa.woowakit.domain.order.domain.event.OrderCompleteEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CartItemDeleteEventHandler {
+
+	private final CartItemRepository cartItemRepository;
+
+	@Order(1)
+	@Transactional
+	@EventListener
+	public void handle(final OrderCompleteEvent event) {
+		deleteCartItems(event);
+	}
+
+	private void deleteCartItems(final OrderCompleteEvent event) {
+		List<Long> productIds = event.getOrderItem().stream()
+			.map(OrderItem::getProductId)
+			.collect(Collectors.toUnmodifiableList());
+		
+		cartItemRepository.deleteAllByProductIdAndMemberId(event.getOrder().getMemberId(), productIds);
+	}
+}

--- a/src/main/java/com/woowa/woowakit/domain/order/domain/handler/CartItemDeletionEventHandler.java
+++ b/src/main/java/com/woowa/woowakit/domain/order/domain/handler/CartItemDeletionEventHandler.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.context.event.EventListener;
-import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,11 +15,10 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class CartItemDeleteEventHandler {
+public class CartItemDeletionEventHandler {
 
 	private final CartItemRepository cartItemRepository;
 
-	@Order(1)
 	@Transactional
 	@EventListener
 	public void handle(final OrderCompleteEvent event) {

--- a/src/main/java/com/woowa/woowakit/domain/order/dto/request/PreOrderCreateCartItemRequest.java
+++ b/src/main/java/com/woowa/woowakit/domain/order/dto/request/PreOrderCreateCartItemRequest.java
@@ -1,0 +1,27 @@
+package com.woowa.woowakit.domain.order.dto.request;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.validation.constraints.NotNull;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class PreOrderCreateCartItemRequest {
+
+	@NotNull(message = "장바구니는 필수 입니다.")
+	private Long cartItemId;
+
+	public static List<Long> listOf(List<PreOrderCreateCartItemRequest> requests) {
+		return requests.stream()
+			.mapToLong(PreOrderCreateCartItemRequest::getCartItemId)
+			.boxed()
+			.collect(Collectors.toUnmodifiableList());
+	}
+}

--- a/src/main/java/com/woowa/woowakit/domain/order/dto/request/PreOrderCreateCartItemRequest.java
+++ b/src/main/java/com/woowa/woowakit/domain/order/dto/request/PreOrderCreateCartItemRequest.java
@@ -18,7 +18,7 @@ public class PreOrderCreateCartItemRequest {
 	@NotNull(message = "장바구니는 필수 입니다.")
 	private Long cartItemId;
 
-	public static List<Long> listOf(List<PreOrderCreateCartItemRequest> requests) {
+	public static List<Long> toCartItemIds(List<PreOrderCreateCartItemRequest> requests) {
 		return requests.stream()
 			.mapToLong(PreOrderCreateCartItemRequest::getCartItemId)
 			.boxed()

--- a/src/main/java/com/woowa/woowakit/domain/order/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/woowa/woowakit/domain/order/dto/response/OrderItemResponse.java
@@ -1,6 +1,7 @@
 package com.woowa.woowakit.domain.order.dto.response;
 
 import com.woowa.woowakit.domain.order.domain.OrderItem;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,19 +12,32 @@ import lombok.NoArgsConstructor;
 @Getter
 public class OrderItemResponse {
 
-    private Long id;
-    private Long productId;
-    private Long quantity;
+	private Long id;
+	private Long productId;
+	private String name;
+	private String image;
+	private Long price;
+	private Long quantity;
 
-    public static OrderItemResponse of(final Long id, final Long productId, final Long quantity) {
-        return new OrderItemResponse(id, productId, quantity);
-    }
+	public static OrderItemResponse of(
+		final Long id,
+		final Long productId,
+		final String name,
+		final String image,
+		final Long price,
+		final Long quantity
+	) {
+		return new OrderItemResponse(id, productId, name, image, price, quantity);
+	}
 
-    public static OrderItemResponse from(final OrderItem orderItem) {
-        return OrderItemResponse.of(
-            orderItem.getId(),
-            orderItem.getProductId(),
-            orderItem.getQuantity().getValue()
-        );
-    }
+	public static OrderItemResponse from(final OrderItem orderItem) {
+		return OrderItemResponse.of(
+			orderItem.getId(),
+			orderItem.getProductId(),
+			orderItem.getName(),
+			orderItem.getImage().getValue(),
+			orderItem.getPrice().getValue(),
+			orderItem.getQuantity().getValue()
+		);
+	}
 }

--- a/src/main/java/com/woowa/woowakit/domain/order/exception/CartItemNotFoundException.java
+++ b/src/main/java/com/woowa/woowakit/domain/order/exception/CartItemNotFoundException.java
@@ -1,0 +1,10 @@
+package com.woowa.woowakit.domain.order.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CartItemNotFoundException extends OrderException {
+
+	public CartItemNotFoundException() {
+		super("존재하지 않은 장바구니 정보입니다.", HttpStatus.BAD_REQUEST);
+	}
+}

--- a/src/test/java/com/woowa/woowakit/domain/cart/domain/CartItemRepositoryTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/cart/domain/CartItemRepositoryTest.java
@@ -13,9 +13,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import com.woowa.woowakit.domain.auth.domain.EncodedPassword;
 import com.woowa.woowakit.domain.auth.domain.Member;
+import com.woowa.woowakit.domain.member.fixture.MemberFixture;
 import com.woowa.woowakit.domain.product.domain.product.Product;
+import com.woowa.woowakit.domain.product.domain.product.ProductName;
+import com.woowa.woowakit.domain.product.fixture.ProductFixture;
 import com.woowa.woowakit.global.config.QuerydslTestConfig;
 
 @DisplayName("CartItemRepository 단위 테스트")
@@ -33,8 +35,8 @@ class CartItemRepositoryTest {
 	@DisplayName("장바구니 id와 회원 id를 바탕으로 장바구니와 상품을 Projection한 클래스를 찾는다.")
 	void findCartItemByIdAndMemberId() {
 		// given
-		Member member = Member.of("jiwonjjang@abcd.com", EncodedPassword.from("jiwonjjang"), "탐탐");
-		Product product = Product.of("상품1", 15000L, "product.img");
+		Member member = MemberFixture.anMember().build();
+		Product product = ProductFixture.anProduct().build();
 
 		entityManager.persist(member);
 		entityManager.persist(product);
@@ -55,10 +57,10 @@ class CartItemRepositoryTest {
 	@DisplayName("장바구니 id와 회원 id를 바탕으로 장바구니를 삭제한다.")
 	void deleteAll() {
 		// given
-		Member member = Member.of("jiwonjjang@abcd.com", EncodedPassword.from("jiwonjjang"), "탐탐");
-		Product product1 = Product.of("상품1", 15000L, "product.img");
-		Product product2 = Product.of("상품2", 15000L, "product.img");
-		Product product3 = Product.of("상품3", 15000L, "product.img");
+		Member member = MemberFixture.anMember().build();
+		Product product1 = ProductFixture.anProduct().name(ProductName.from("상품1")).build();
+		Product product2 = ProductFixture.anProduct().name(ProductName.from("상품2")).build();
+		Product product3 = ProductFixture.anProduct().name(ProductName.from("상품3")).build();
 
 		entityManager.persist(member);
 		entityManager.persist(product1);

--- a/src/test/java/com/woowa/woowakit/domain/cart/domain/CartItemRepositoryTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/cart/domain/CartItemRepositoryTest.java
@@ -1,0 +1,85 @@
+package com.woowa.woowakit.domain.cart.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.woowa.woowakit.domain.auth.domain.EncodedPassword;
+import com.woowa.woowakit.domain.auth.domain.Member;
+import com.woowa.woowakit.domain.product.domain.product.Product;
+import com.woowa.woowakit.global.config.QuerydslTestConfig;
+
+@DisplayName("CartItemRepository 단위 테스트")
+@DataJpaTest
+@Import(QuerydslTestConfig.class)
+class CartItemRepositoryTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Autowired
+	private CartItemRepository cartItemRepository;
+
+	@Test
+	@DisplayName("장바구니 id와 회원 id를 바탕으로 장바구니와 상품을 Projection한 클래스를 찾는다.")
+	void findCartItemByIdAndMemberId() {
+		// given
+		Member member = Member.of("jiwonjjang@abcd.com", EncodedPassword.from("jiwonjjang"), "탐탐");
+		Product product = Product.of("상품1", 15000L, "product.img");
+
+		entityManager.persist(member);
+		entityManager.persist(product);
+
+		CartItem cartItem = CartItem.of(member.getId(), product.getId());
+
+		entityManager.persist(cartItem);
+
+		// when
+		CartItemSpecification result = cartItemRepository.findCartItemByIdAndMemberId(
+			member.getId(), cartItem.getId()).get();
+
+		// then
+		assertThat(result).extracting(CartItemSpecification::getProductId).isEqualTo(product.getId());
+	}
+
+	@Test
+	@DisplayName("장바구니 id와 회원 id를 바탕으로 장바구니를 삭제한다.")
+	void deleteAll() {
+		// given
+		Member member = Member.of("jiwonjjang@abcd.com", EncodedPassword.from("jiwonjjang"), "탐탐");
+		Product product1 = Product.of("상품1", 15000L, "product.img");
+		Product product2 = Product.of("상품2", 15000L, "product.img");
+		Product product3 = Product.of("상품3", 15000L, "product.img");
+
+		entityManager.persist(member);
+		entityManager.persist(product1);
+		entityManager.persist(product2);
+		entityManager.persist(product3);
+
+		CartItem cartItem1 = CartItem.of(member.getId(), product1.getId());
+		CartItem cartItem2 = CartItem.of(member.getId(), product2.getId());
+		CartItem cartItem3 = CartItem.of(member.getId(), product3.getId());
+
+		entityManager.persist(cartItem1);
+		entityManager.persist(cartItem2);
+		entityManager.persist(cartItem3);
+
+		// when
+		cartItemRepository.deleteAllByProductIdAndMemberId(member.getId(),
+			List.of(product1.getId(), product2.getId(), product3.getId()));
+
+		// then
+		List<CartItemSpecification> result = cartItemRepository.findCartItemByMemberId(member.getId());
+		assertThat(result).isEmpty();
+	}
+
+}

--- a/src/test/java/com/woowa/woowakit/domain/member/fixture/MemberFixture.java
+++ b/src/test/java/com/woowa/woowakit/domain/member/fixture/MemberFixture.java
@@ -1,0 +1,19 @@
+package com.woowa.woowakit.domain.member.fixture;
+
+import static com.woowa.woowakit.domain.auth.domain.Member.*;
+
+import com.woowa.woowakit.domain.auth.domain.Email;
+import com.woowa.woowakit.domain.auth.domain.EncodedPassword;
+import com.woowa.woowakit.domain.auth.domain.Member;
+import com.woowa.woowakit.domain.auth.domain.Role;
+
+public class MemberFixture {
+
+	public static MemberBuilder anMember() {
+		return Member.builder()
+			.name("탐탐")
+			.email(Email.from("jiwonjjang@jiwon.com"))
+			.encodedPassword(EncodedPassword.from("hellojiwon1234"))
+			.role(Role.USER);
+	}
+}

--- a/src/test/java/com/woowa/woowakit/domain/order/application/OrderServiceConcurrencyTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/order/application/OrderServiceConcurrencyTest.java
@@ -1,0 +1,81 @@
+package com.woowa.woowakit.domain.order.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.woowa.woowakit.domain.auth.domain.AuthPrincipal;
+import com.woowa.woowakit.domain.auth.domain.Member;
+import com.woowa.woowakit.domain.auth.domain.MemberRepository;
+import com.woowa.woowakit.domain.cart.domain.CartItemRepository;
+import com.woowa.woowakit.domain.member.fixture.MemberFixture;
+import com.woowa.woowakit.domain.model.Quantity;
+import com.woowa.woowakit.domain.order.dto.request.OrderCreateRequest;
+import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateRequest;
+import com.woowa.woowakit.domain.payment.domain.PaymentService;
+import com.woowa.woowakit.domain.product.domain.product.Product;
+import com.woowa.woowakit.domain.product.domain.product.ProductRepository;
+import com.woowa.woowakit.domain.product.fixture.ProductFixture;
+
+@SpringBootTest
+@DisplayName("OrderService 동시성 테스트")
+class OrderServiceConcurrencyTest {
+
+	@Autowired
+	private CartItemRepository cartItemRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Autowired
+	private OrderService orderService;
+
+	@MockBean
+	private PaymentService paymentService;
+
+	@Test
+	@DisplayName("주문 동시성 테스트")
+	void test1() throws Exception {
+		// given
+		Member member = memberRepository.save(MemberFixture.anMember().build());
+
+		Product product = productRepository.save(ProductFixture.anProduct().build());
+
+		int threadCount = 10;
+		for (int i = 0; i < threadCount; i++) {
+			PreOrderCreateRequest request = PreOrderCreateRequest.of(product.getId(), 10L);
+			orderService.preOrder(AuthPrincipal.from(member), request);
+		}
+
+		// when
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+		CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+		for (int i = 0; i < threadCount; i++) {
+			OrderCreateRequest request = OrderCreateRequest.of((long)(i + 1), "test");
+			executorService.submit(() -> {
+				try {
+					orderService.order(AuthPrincipal.from(member), request);
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
+		countDownLatch.await();
+		productRepository.flush();
+
+		// then
+		Product afterProduct = productRepository.findById(product.getId()).orElseThrow();
+		assertThat(afterProduct.getQuantity()).isEqualTo(Quantity.from(0));
+	}
+}

--- a/src/test/java/com/woowa/woowakit/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/order/application/OrderServiceTest.java
@@ -1,8 +1,14 @@
 package com.woowa.woowakit.domain.order.application;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -15,9 +21,13 @@ import com.woowa.woowakit.domain.auth.domain.AuthPrincipal;
 import com.woowa.woowakit.domain.auth.domain.EncodedPassword;
 import com.woowa.woowakit.domain.auth.domain.Member;
 import com.woowa.woowakit.domain.auth.domain.MemberRepository;
+import com.woowa.woowakit.domain.cart.domain.CartItem;
+import com.woowa.woowakit.domain.cart.domain.CartItemRepository;
 import com.woowa.woowakit.domain.model.Quantity;
 import com.woowa.woowakit.domain.order.dto.request.OrderCreateRequest;
+import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateCartItemRequest;
 import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateRequest;
+import com.woowa.woowakit.domain.order.dto.response.PreOrderResponse;
 import com.woowa.woowakit.domain.payment.domain.PaymentService;
 import com.woowa.woowakit.domain.product.domain.product.Product;
 import com.woowa.woowakit.domain.product.domain.product.ProductImage;
@@ -28,6 +38,9 @@ import com.woowa.woowakit.domain.product.domain.product.ProductStatus;
 
 @SpringBootTest
 class OrderServiceTest {
+
+	@Autowired
+	private CartItemRepository cartItemRepository;
 
 	@Autowired
 	private MemberRepository memberRepository;
@@ -82,6 +95,39 @@ class OrderServiceTest {
 
 		// then
 		Product afterProduct = productRepository.findById(product.getId()).orElseThrow();
-		Assertions.assertThat(afterProduct.getQuantity()).isEqualTo(Quantity.from(0));
+		assertThat(afterProduct.getQuantity()).isEqualTo(Quantity.from(0));
+	}
+
+	@Test
+	@DisplayName("장바구니 주문 테스트")
+	void test2() {
+		// given
+		Member member = memberRepository.save(Member.of(
+			"test1@test.com",
+			EncodedPassword.from("test"),
+			"test1"));
+
+		Product product = productRepository.save(Product.builder()
+			.price(ProductPrice.from(10000L))
+			.quantity(Quantity.from(100))
+			.imageUrl(ProductImage.from("/path"))
+			.name(ProductName.from("된장 밀키트"))
+			.status(ProductStatus.IN_STOCK)
+			.build());
+
+		CartItem cartItem = CartItem.of(member.getId(), product.getId(), 3);
+		cartItemRepository.save(cartItem);
+
+		PreOrderCreateCartItemRequest request = new PreOrderCreateCartItemRequest(cartItem.getId());
+		PreOrderResponse preOrderResponse = orderService.preOrderCartItems(AuthPrincipal.from(member), List.of(request));
+
+		// when
+		OrderCreateRequest orderCreateRequest = OrderCreateRequest.of(preOrderResponse.getId(), "test");
+		orderService.order(AuthPrincipal.from(member), orderCreateRequest);
+
+		// then
+		Product afterProduct = productRepository.findById(product.getId()).orElseThrow();
+		assertThat(cartItemRepository.findCartItemByIdAndMemberId(member.getId(), cartItem.getId())).isNotPresent();
+		assertThat(afterProduct.getQuantity()).isEqualTo(Quantity.from(97));
 	}
 }

--- a/src/test/java/com/woowa/woowakit/domain/order/application/OrderServiceTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/order/application/OrderServiceTest.java
@@ -3,19 +3,13 @@ package com.woowa.woowakit.domain.order.application;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 
 import com.woowa.woowakit.domain.auth.domain.AuthPrincipal;
 import com.woowa.woowakit.domain.auth.domain.EncodedPassword;
@@ -23,10 +17,13 @@ import com.woowa.woowakit.domain.auth.domain.Member;
 import com.woowa.woowakit.domain.auth.domain.MemberRepository;
 import com.woowa.woowakit.domain.cart.domain.CartItem;
 import com.woowa.woowakit.domain.cart.domain.CartItemRepository;
+import com.woowa.woowakit.domain.member.fixture.MemberFixture;
 import com.woowa.woowakit.domain.model.Quantity;
+import com.woowa.woowakit.domain.order.domain.OrderMapper;
+import com.woowa.woowakit.domain.order.domain.handler.CartItemDeletionEventHandler;
+import com.woowa.woowakit.domain.order.domain.handler.ProductQuantityEventHandler;
 import com.woowa.woowakit.domain.order.dto.request.OrderCreateRequest;
 import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateCartItemRequest;
-import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateRequest;
 import com.woowa.woowakit.domain.order.dto.response.PreOrderResponse;
 import com.woowa.woowakit.domain.payment.domain.PaymentService;
 import com.woowa.woowakit.domain.product.domain.product.Product;
@@ -35,8 +32,13 @@ import com.woowa.woowakit.domain.product.domain.product.ProductName;
 import com.woowa.woowakit.domain.product.domain.product.ProductPrice;
 import com.woowa.woowakit.domain.product.domain.product.ProductRepository;
 import com.woowa.woowakit.domain.product.domain.product.ProductStatus;
+import com.woowa.woowakit.domain.product.fixture.ProductFixture;
+import com.woowa.woowakit.global.config.QuerydslTestConfig;
 
-@SpringBootTest
+@DisplayName("OrderService 단위 테스트")
+@DataJpaTest
+@Import({OrderService.class, QuerydslTestConfig.class, OrderMapper.class, CartItemDeletionEventHandler.class,
+	ProductQuantityEventHandler.class})
 class OrderServiceTest {
 
 	@Autowired
@@ -55,65 +57,12 @@ class OrderServiceTest {
 	private PaymentService paymentService;
 
 	@Test
-	@DisplayName("주문 동시성 테스트")
-	void test1() throws Exception {
-		// given
-		Member member = memberRepository.save(Member.of(
-			"test@test.com",
-			EncodedPassword.from("test"),
-			"test"));
-
-		Product product = productRepository.save(Product.builder()
-			.price(ProductPrice.from(10000L))
-			.quantity(Quantity.from(100))
-			.imageUrl(ProductImage.from("/path"))
-			.name(ProductName.from("된장 밀키트"))
-			.status(ProductStatus.IN_STOCK)
-			.build());
-
-		int threadCount = 10;
-		for (int i = 0; i < threadCount; i++) {
-			PreOrderCreateRequest request = PreOrderCreateRequest.of(product.getId(), 10L);
-			orderService.preOrder(AuthPrincipal.from(member), request);
-		}
-
-		// when
-		ExecutorService executorService = Executors.newFixedThreadPool(32);
-		CountDownLatch countDownLatch = new CountDownLatch(threadCount);
-		for (int i = 0; i < threadCount; i++) {
-			OrderCreateRequest request = OrderCreateRequest.of((long)(i + 1), "test");
-			executorService.submit(() -> {
-				try {
-					orderService.order(AuthPrincipal.from(member), request);
-				} finally {
-					countDownLatch.countDown();
-				}
-			});
-		}
-		countDownLatch.await();
-		productRepository.flush();
-
-		// then
-		Product afterProduct = productRepository.findById(product.getId()).orElseThrow();
-		assertThat(afterProduct.getQuantity()).isEqualTo(Quantity.from(0));
-	}
-
-	@Test
 	@DisplayName("장바구니 주문 테스트")
-	void test2() {
+	void test1() {
 		// given
-		Member member = memberRepository.save(Member.of(
-			"test1@test.com",
-			EncodedPassword.from("test"),
-			"test1"));
+		Member member = memberRepository.save(MemberFixture.anMember().build());
 
-		Product product = productRepository.save(Product.builder()
-			.price(ProductPrice.from(10000L))
-			.quantity(Quantity.from(100))
-			.imageUrl(ProductImage.from("/path"))
-			.name(ProductName.from("된장 밀키트"))
-			.status(ProductStatus.IN_STOCK)
-			.build());
+		Product product = productRepository.save(ProductFixture.anProduct().build());
 
 		CartItem cartItem = CartItem.of(member.getId(), product.getId(), 3);
 		cartItemRepository.save(cartItem);

--- a/src/test/java/com/woowa/woowakit/domain/product/fixture/ProductFixture.java
+++ b/src/test/java/com/woowa/woowakit/domain/product/fixture/ProductFixture.java
@@ -1,0 +1,20 @@
+package com.woowa.woowakit.domain.product.fixture;
+
+import com.woowa.woowakit.domain.model.Quantity;
+import com.woowa.woowakit.domain.product.domain.product.Product;
+import com.woowa.woowakit.domain.product.domain.product.ProductImage;
+import com.woowa.woowakit.domain.product.domain.product.ProductName;
+import com.woowa.woowakit.domain.product.domain.product.ProductPrice;
+import com.woowa.woowakit.domain.product.domain.product.ProductStatus;
+
+public class ProductFixture {
+
+	public static Product.ProductBuilder anProduct() {
+		return Product.builder()
+			.name(ProductName.from("우아한 밀키트"))
+			.price(ProductPrice.from(10000L))
+			.imageUrl(ProductImage.from("woowakit.img"))
+			.quantity(Quantity.from(100L))
+			.status(ProductStatus.IN_STOCK);
+	}
+}

--- a/src/test/java/integration/helper/CartItemHelper.java
+++ b/src/test/java/integration/helper/CartItemHelper.java
@@ -15,7 +15,22 @@ public class CartItemHelper {
 		return CommonRestAssuredUtils.post("/cart-items", createCartItemAddRequest(productId, quantity), accessToken);
 	}
 
+	public static Long addCartItemAndGetID(
+		final long productId,
+		final long quantity,
+		final String accessToken
+	) {
+		String location = CommonRestAssuredUtils.post("/cart-items", createCartItemAddRequest(productId, quantity),
+			accessToken).header("Location");
+		return getIdFrom(location);
+	}
+
 	public static CartItemAddRequest createCartItemAddRequest(long productId, long quantity) {
 		return CartItemAddRequest.of(productId, quantity);
+	}
+
+	private static Long getIdFrom(String location) {
+		String[] parts = location.split("/");
+		return Long.parseLong(parts[parts.length - 1]);
 	}
 }

--- a/src/test/java/integration/helper/OrderHelper.java
+++ b/src/test/java/integration/helper/OrderHelper.java
@@ -1,6 +1,9 @@
 package integration.helper;
 
+import java.util.List;
+
 import com.woowa.woowakit.domain.order.dto.request.OrderCreateRequest;
+import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateCartItemRequest;
 import com.woowa.woowakit.domain.order.dto.request.PreOrderCreateRequest;
 import com.woowa.woowakit.domain.order.dto.response.PreOrderResponse;
 import io.restassured.response.ExtractableResponse;
@@ -9,12 +12,23 @@ import io.restassured.response.Response;
 public class OrderHelper {
 
     public static ExtractableResponse<Response> createPreOrder(
-        final PreOrderCreateRequest request, final String accessToken) {
+        final PreOrderCreateRequest request, final String accessToken
+    ) {
         return CommonRestAssuredUtils.post("/orders/pre", request, accessToken);
+    }
+
+    public static ExtractableResponse<Response> createPreOrder(
+        final PreOrderCreateCartItemRequest request, final String accessToken
+    ) {
+        return CommonRestAssuredUtils.post("/orders/pre-cart-item", List.of(request), accessToken);
     }
 
     public static PreOrderCreateRequest createPreOrderCreateRequest(Long productId) {
         return PreOrderCreateRequest.of(productId, 1L);
+    }
+
+    public static PreOrderCreateCartItemRequest createPreOrderCreateCartItemRequest(Long cartItemId) {
+        return new PreOrderCreateCartItemRequest(cartItemId);
     }
 
     public static Long createPreOrderAndGetId(Long productId, String accessToken) {

--- a/src/test/java/integration/order/OrderIntegrationTest.java
+++ b/src/test/java/integration/order/OrderIntegrationTest.java
@@ -15,6 +15,7 @@ import com.woowa.woowakit.domain.order.dto.response.PreOrderResponse;
 import com.woowa.woowakit.domain.payment.domain.PaymentService;
 
 import integration.IntegrationTest;
+import integration.helper.CartItemHelper;
 import integration.helper.CommonRestAssuredUtils;
 import integration.helper.MemberHelper;
 import integration.helper.OrderHelper;
@@ -38,6 +39,28 @@ class OrderIntegrationTest extends IntegrationTest {
 		// when
 		ExtractableResponse<Response> response = OrderHelper.createPreOrder(
 			OrderHelper.createPreOrderCreateRequest(productId), accessToken);
+
+		// then
+		PreOrderResponse preOrderResponse = response.as(PreOrderResponse.class);
+		assertThat(response.statusCode()).isEqualTo(201);
+		assertThat(preOrderResponse).extracting(PreOrderResponse::getId,
+				PreOrderResponse::getUuid)
+			.isNotNull();
+		assertThat(preOrderResponse).extracting(PreOrderResponse::getOrderItems).asList()
+			.hasSize(1);
+	}
+
+	@Test
+	@DisplayName("장바구니 상품을 바탕으로 가주문을 생성한다")
+	void preOrderByCartItems() {
+		// given
+		Long productId = ProductHelper.createProductAndSetUp();
+		String accessToken = MemberHelper.signUpAndLogIn();
+		Long cartItemId = Long.parseLong(CartItemHelper.addCartItem(productId, 10L, accessToken).header("Location").split("/")[2]);
+
+		// when
+		ExtractableResponse<Response> response = OrderHelper.createPreOrder(
+			OrderHelper.createPreOrderCreateCartItemRequest(cartItemId), accessToken);
 
 		// then
 		PreOrderResponse preOrderResponse = response.as(PreOrderResponse.class);

--- a/src/test/java/integration/order/OrderIntegrationTest.java
+++ b/src/test/java/integration/order/OrderIntegrationTest.java
@@ -56,7 +56,7 @@ class OrderIntegrationTest extends IntegrationTest {
 		// given
 		Long productId = ProductHelper.createProductAndSetUp();
 		String accessToken = MemberHelper.signUpAndLogIn();
-		Long cartItemId = Long.parseLong(CartItemHelper.addCartItem(productId, 10L, accessToken).header("Location").split("/")[2]);
+		Long cartItemId = CartItemHelper.addCartItemAndGetID(productId, 10L, accessToken);
 
 		// when
 		ExtractableResponse<Response> response = OrderHelper.createPreOrder(


### PR DESCRIPTION
안녕하세요 오늘은 비가 오네요

## Description
장바구니를 바탕으로 상품을 주문하는 로직을 구현했습니다.
장바구니 상품의 일부를 체크해서 주문하는 로직으로 구현하였습니다.
현재 order 로직 자체는 장바구니와 크게 상관이 없기 때문에 건들지 않았고, preOrder 로직이 현재 바로 주문 로직과 달라 이 부분만 새로 만들고 end-point도 새로 만들었습니다.
그리고 상품이 주문된 경우 장바구니를 삭제하는 로직이 필요하여 기존 이벤트에 장바구니를 지우는 event를 추가하였습니다.
궁금한 점이 있으시다면 과감한 질문 부탁드리고, 코드가 개판일 수 있으니 사나운 리뷰 부탁드립니다.

## Changes
커밋 로그 확인 요망
- CartItem 관련 쿼리 추가
- Service 로직 추가
- Event 추가

## Test Checklist
CartItemRepository 단위 테스트
- 장바구니 id와 회원 id를 바탕으로 장바구니와 상품을 Projection한 클래스를 찾는다.
- 장바구니 id와 회원 id를 바탕으로 장바구니를 삭제한다.

OrderService 단위 테스트
- 장바구니 주문 테스트
Order 인수 테스트
- 장바구니 상품을 바탕으로 가주문을 생성한다
