### PR TITLE
fix: 결제 성능 테스트를 위해 Thread sleep 빈으로 변경

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -9,7 +9,7 @@ name: Dev-Stage CD
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "test/pay" ]
 
 permissions:
   contents: read

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -9,7 +9,7 @@ name: Dev-Stage CD
 
 on:
   push:
-    branches: [ "test/pay" ]
+    branches: [ "dev" ]
 
 permissions:
   contents: read

--- a/src/main/java/com/woowa/woowakit/global/config/PayConfig.java
+++ b/src/main/java/com/woowa/woowakit/global/config/PayConfig.java
@@ -1,8 +1,16 @@
 package com.woowa.woowakit.global.config;
 
+import com.woowa.woowakit.domain.payment.domain.PaymentService;
+import com.woowa.woowakit.infra.payment.toss.ThreadSleepClient;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
 public class PayConfig {
+
+	@Profile("prod")
+	public PaymentService paymentService() {
+		return new ThreadSleepClient();
+	}
 
 }

--- a/src/main/java/com/woowa/woowakit/global/config/PayConfig.java
+++ b/src/main/java/com/woowa/woowakit/global/config/PayConfig.java
@@ -2,6 +2,7 @@ package com.woowa.woowakit.global.config;
 
 import com.woowa.woowakit.domain.payment.domain.PaymentService;
 import com.woowa.woowakit.infra.payment.toss.ThreadSleepClient;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
@@ -9,6 +10,7 @@ import org.springframework.context.annotation.Profile;
 public class PayConfig {
 
 	@Profile("prod")
+	@Bean
 	public PaymentService paymentService() {
 		return new ThreadSleepClient();
 	}

--- a/src/main/java/com/woowa/woowakit/infra/payment/toss/ThreadSleepClient.java
+++ b/src/main/java/com/woowa/woowakit/infra/payment/toss/ThreadSleepClient.java
@@ -1,0 +1,25 @@
+package com.woowa.woowakit.infra.payment.toss;
+
+import com.woowa.woowakit.domain.model.Money;
+import com.woowa.woowakit.domain.payment.domain.PaymentService;
+import java.util.Random;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ThreadSleepClient implements PaymentService {
+
+	public static final double MEAN = 1.3;
+	public static final double STANDARD_DEVIATION = 0.2;
+	private final Random random = new Random();
+
+	@Override
+	public void validatePayment(String paymentKey, String orderToken, Money totalPrice) {
+		try {
+			long latancyMs = (long) (random.nextGaussian(MEAN, STANDARD_DEVIATION) * 1000);
+			log.info("결제를 위해 {} ms 대기합니다.", latancyMs);
+			Thread.sleep(latancyMs);
+		} catch (InterruptedException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+}

--- a/src/main/java/com/woowa/woowakit/infra/payment/toss/ThreadSleepClient.java
+++ b/src/main/java/com/woowa/woowakit/infra/payment/toss/ThreadSleepClient.java
@@ -8,14 +8,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ThreadSleepClient implements PaymentService {
 
-	public static final double MEAN = 1.3;
-	public static final double STANDARD_DEVIATION = 0.2;
-	private final Random random = new Random();
+	private static final double MEAN = 1.3;
+	private static final double STANDARD_DEVIATION = 0.2;
 
 	@Override
 	public void validatePayment(String paymentKey, String orderToken, Money totalPrice) {
 		try {
-			long latancyMs = (long) (random.nextGaussian(MEAN, STANDARD_DEVIATION) * 1000);
+			long latancyMs = (long) ((MEAN + STANDARD_DEVIATION * new Random().nextGaussian())
+				* 1000);
 			log.info("결제를 위해 {} ms 대기합니다.", latancyMs);
 			Thread.sleep(latancyMs);
 		} catch (InterruptedException e) {

--- a/src/main/java/com/woowa/woowakit/infra/payment/toss/TossPaymentClient.java
+++ b/src/main/java/com/woowa/woowakit/infra/payment/toss/TossPaymentClient.java
@@ -9,7 +9,6 @@ import java.util.Base64;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -20,7 +19,6 @@ import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
 @Component
-@Profile("!prod")
 public class TossPaymentClient implements PaymentService {
 
 	private final Duration timeout;

--- a/src/main/java/com/woowa/woowakit/infra/payment/toss/TossPaymentClient.java
+++ b/src/main/java/com/woowa/woowakit/infra/payment/toss/TossPaymentClient.java
@@ -1,27 +1,26 @@
 package com.woowa.woowakit.infra.payment.toss;
 
+import com.woowa.woowakit.domain.model.Money;
+import com.woowa.woowakit.domain.payment.domain.PaymentService;
+import com.woowa.woowakit.infra.payment.toss.dto.TossPaymentErrorResponse;
+import com.woowa.woowakit.infra.payment.toss.dto.TossPaymentRequest;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
-
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
-
-import com.woowa.woowakit.domain.model.Money;
-import com.woowa.woowakit.domain.payment.domain.PaymentService;
-import com.woowa.woowakit.infra.payment.toss.dto.TossPaymentErrorResponse;
-import com.woowa.woowakit.infra.payment.toss.dto.TossPaymentRequest;
-
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
 @Component
+@Profile("!prod")
 public class TossPaymentClient implements PaymentService {
 
 	private final Duration timeout;

--- a/src/test/java/com/woowa/woowakit/infra/payment/toss/ThreadSleepClientTest.java
+++ b/src/test/java/com/woowa/woowakit/infra/payment/toss/ThreadSleepClientTest.java
@@ -1,0 +1,18 @@
+package com.woowa.woowakit.infra.payment.toss;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ThreadSleepClient 테스트")
+class ThreadSleepClientTest {
+
+	@Test
+	@DisplayName("결제 지연시간 테스트")
+	void test() {
+		long start = System.currentTimeMillis();
+		ThreadSleepClient threadSleepClient = new ThreadSleepClient();
+		threadSleepClient.validatePayment("paymentKey", "orderToken", null);
+		Assertions.assertThat(System.currentTimeMillis() - start).isGreaterThan(500);
+	}
+}


### PR DESCRIPTION
## Description
토스와 연결된 빈을 thread sleep이 동작하는 빈으로 변경합니다
이는 profile이 prod 환경에서만 동작합니다

현재 prod가 dev 서버에서 테스트가 이루어지고 있기 때문에 이는 실제 배포 전에 수정될 예정입니다

## Changes

## Test Checklist
