### PR TITLE
재고 정합성 스케쥴러 로깅 추가

### DIFF
--- a/src/main/java/com/woowa/woowakit/domain/product/application/StockScheduler.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/application/StockScheduler.java
@@ -28,7 +28,7 @@ public class StockScheduler {
 		List<Long> productIds = productRepository.findAllIds();
 
 		for (Long productId : productIds) {
-			log.info("상품 정합성 시작 = {}", LocalDateTime.now());
+			log.info("상품 정합성 시작 = {} productId = {}", LocalDateTime.now(), productId);
 			stockProcessingService.doProcess(productId, LocalDate.now(ZoneId.of("Asia/Seoul")));
 			log.info("상품 정합성 끝 = {}", LocalDateTime.now());
 		}

--- a/src/main/java/com/woowa/woowakit/domain/product/application/StockScheduler.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/application/StockScheduler.java
@@ -1,6 +1,7 @@
 package com.woowa.woowakit.domain.product.application;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 
@@ -22,10 +23,14 @@ public class StockScheduler {
 
 	@Scheduled(zone = "Asia/Seoul", cron = "0 0 0 * * ?")
 	public void trigger() {
+		long startEnd = System.currentTimeMillis();
+		log.info("재고 정합성 스케쥴러 시작 = {}", LocalDateTime.now());
 		List<Long> productIds = productRepository.findAllIds();
 
 		for (Long productId : productIds) {
 			stockProcessingService.doProcess(productId, LocalDate.now(ZoneId.of("Asia/Seoul")));
 		}
+		long diffTime = System.currentTimeMillis() - startEnd;
+		log.info("재고 정합성 스케쥴러 끝 = {} , 걸린 시간 = {} ms ", LocalDateTime.now(), diffTime);
 	}
 }

--- a/src/main/java/com/woowa/woowakit/domain/product/application/StockScheduler.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/application/StockScheduler.java
@@ -28,7 +28,9 @@ public class StockScheduler {
 		List<Long> productIds = productRepository.findAllIds();
 
 		for (Long productId : productIds) {
+			log.info("상품 정합성 시작 = {}", LocalDateTime.now());
 			stockProcessingService.doProcess(productId, LocalDate.now(ZoneId.of("Asia/Seoul")));
+			log.info("상품 정합성 끝 = {}", LocalDateTime.now());
 		}
 		long diffTime = System.currentTimeMillis() - startEnd;
 		log.info("재고 정합성 스케쥴러 끝 = {} , 걸린 시간 = {} ms ", LocalDateTime.now(), diffTime);


### PR DESCRIPTION
## Description

재고 정합성 스케쥴러 로깅 추가

## Changes
```java 
        @Scheduled(zone = "Asia/Seoul", cron = "0 0 0 * * ?")
	public void trigger() {
		long startEnd = System.currentTimeMillis();
		log.info("재고 정합성 스케쥴러 시작 = {}", LocalDateTime.now());
		List<Long> productIds = productRepository.findAllIds();

		for (Long productId : productIds) {
			stockProcessingService.doProcess(productId, LocalDate.now(ZoneId.of("Asia/Seoul")));
		}
		long diffTime = System.currentTimeMillis() - startEnd;
		log.info("재고 정합성 스케쥴러 끝 = {} , 걸린 시간 = {} ms ", LocalDateTime.now(), diffTime);
	}
```

## Test Checklist
