### PR TITLE
feat: 일일 판매량 순으로 조회할 수 있도록 변경

### DIFF
--- a/src/main/java/com/woowa/woowakit/domain/product/api/ProductController.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/api/ProductController.java
@@ -1,5 +1,20 @@
 package com.woowa.woowakit.domain.product.api;
 
+import java.net.URI;
+import java.util.List;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.woowa.woowakit.domain.auth.annotation.Admin;
 import com.woowa.woowakit.domain.product.application.ProductService;
 import com.woowa.woowakit.domain.product.application.StockService;
@@ -8,19 +23,9 @@ import com.woowa.woowakit.domain.product.dto.request.ProductSearchRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductStatusUpdateRequest;
 import com.woowa.woowakit.domain.product.dto.request.StockCreateRequest;
 import com.woowa.woowakit.domain.product.dto.response.ProductDetailResponse;
-import java.net.URI;
-import java.util.List;
-import javax.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -46,7 +51,7 @@ public class ProductController {
 
 	@GetMapping
 	public ResponseEntity<List<ProductDetailResponse>> searchProducts(
-		ProductSearchRequest request) {
+		@Valid @ModelAttribute final ProductSearchRequest request) {
 		log.info("productKeyword: {}, lastProductId: {} 상품 조회", request.getProductKeyword(),
 			request.getLastProductId());
 		final List<ProductDetailResponse> response = productService.searchProducts(request);
@@ -59,7 +64,8 @@ public class ProductController {
 		@PathVariable final Long id,
 		@Valid @RequestBody final StockCreateRequest request
 	) {
-		log.info("[Request] ProductController.addStock(): productId = {}, addStock = [expiryDate:{}, quantity: {}]", id, request.getExpiryDate(), request.getQuantity());
+		log.info("[Request] ProductController.addStock(): productId = {}, addStock = [expiryDate:{}, quantity: {}]", id,
+			request.getExpiryDate(), request.getQuantity());
 		long resultId = stockService.create(request, id);
 		return ResponseEntity.created(URI.create("/products/" + id + "/stocks/" + resultId))
 			.build();
@@ -71,7 +77,8 @@ public class ProductController {
 		@PathVariable final Long id,
 		@Valid @RequestBody final ProductStatusUpdateRequest request
 	) {
-		log.info("[Request] ProductController.updateStatus(): productId = {}, productStatus = {}", id, request.getProductStatus().name());
+		log.info("[Request] ProductController.updateStatus(): productId = {}, productStatus = {}", id,
+			request.getProductStatus().name());
 		productService.updateStatus(id, request);
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/ProductSalesRepository.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/ProductSalesRepository.java
@@ -1,0 +1,11 @@
+package com.woowa.woowakit.domain.product.domain;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.woowa.woowakit.domain.product.domain.product.ProductSales;
+
+public interface ProductSalesRepository extends JpaRepository<ProductSales, Long> {
+	List<ProductSales> findByProductId(Long productId);
+}

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductName.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductName.java
@@ -1,5 +1,7 @@
 package com.woowa.woowakit.domain.product.domain.product;
 
+import java.util.Objects;
+
 import javax.persistence.Embeddable;
 
 import lombok.AccessLevel;
@@ -17,5 +19,20 @@ public class ProductName {
 
 	public static ProductName from(final String name) {
 		return new ProductName(name);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		ProductName that = (ProductName)o;
+		return Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
 	}
 }

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSales.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSales.java
@@ -2,7 +2,7 @@ package com.woowa.woowakit.domain.product.domain.product;
 
 import java.time.LocalDate;
 
-import javax.persistence.Convert;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -11,7 +11,6 @@ import javax.persistence.Table;
 
 import com.woowa.woowakit.domain.model.BaseEntity;
 import com.woowa.woowakit.domain.model.Quantity;
-import com.woowa.woowakit.domain.model.converter.QuantityConverter;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -30,15 +29,19 @@ public class ProductSales extends BaseEntity {
 
 	private Long productId;
 
-	@Convert(converter = QuantityConverter.class)
-	private Quantity sale;
+	@Embedded
+	private SaleQuantity sale;
 
 	private LocalDate saleDate;
 
 	@Builder
-	public ProductSales(Long productId, Quantity sale, LocalDate saleDate) {
+	public ProductSales(
+		final Long productId,
+		final Quantity sale,
+		final LocalDate saleDate
+	) {
 		this.productId = productId;
-		this.sale = sale;
+		this.sale = SaleQuantity.from(sale.getValue());
 		this.saleDate = saleDate;
 	}
 }

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSales.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSales.java
@@ -1,0 +1,44 @@
+package com.woowa.woowakit.domain.product.domain.product;
+
+import java.time.LocalDate;
+
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import com.woowa.woowakit.domain.model.BaseEntity;
+import com.woowa.woowakit.domain.model.Quantity;
+import com.woowa.woowakit.domain.model.converter.QuantityConverter;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "product_sales")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ProductSales extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long productId;
+
+	@Convert(converter = QuantityConverter.class)
+	private Quantity sale;
+
+	private LocalDate saleDate;
+
+	@Builder
+	public ProductSales(Long productId, Quantity sale, LocalDate saleDate) {
+		this.productId = productId;
+		this.sale = sale;
+		this.saleDate = saleDate;
+	}
+}

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSearchCondition.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSearchCondition.java
@@ -1,5 +1,7 @@
 package com.woowa.woowakit.domain.product.domain.product;
 
+import java.time.LocalDate;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +16,14 @@ public class ProductSearchCondition {
 
 	private int pageSize;
 
-	public static ProductSearchCondition of(final String productKeyword, final Long lastProductId, final int pageSize) {
-		return new ProductSearchCondition(productKeyword, lastProductId, pageSize);
+	private LocalDate saleDate;
+
+	public static ProductSearchCondition of(
+		final String productKeyword,
+		final Long lastProductId,
+		final int pageSize,
+		final LocalDate saleDate
+	) {
+		return new ProductSearchCondition(productKeyword, lastProductId, pageSize, saleDate);
 	}
 }

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/product/SaleQuantity.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/product/SaleQuantity.java
@@ -1,0 +1,51 @@
+package com.woowa.woowakit.domain.product.domain.product;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import com.woowa.woowakit.domain.product.exception.ProductQuantityNegativeException;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SaleQuantity {
+
+	@Column(name = "sale")
+	private long value;
+
+	private SaleQuantity(final long value) {
+		validQuantity(value);
+		this.value = value;
+	}
+
+	public static SaleQuantity from(final long saleQuantity) {
+		return new SaleQuantity(saleQuantity);
+	}
+
+	private void validQuantity(final long value) {
+		if (value < 0) {
+			throw new ProductQuantityNegativeException();
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		SaleQuantity that = (SaleQuantity)o;
+		return value == that.value;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(value);
+	}
+}

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/stock/StockConsistencyProcessor.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/stock/StockConsistencyProcessor.java
@@ -1,12 +1,15 @@
 package com.woowa.woowakit.domain.product.domain.stock;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.woowa.woowakit.domain.model.Quantity;
+import com.woowa.woowakit.domain.product.domain.ProductSalesRepository;
 import com.woowa.woowakit.domain.product.domain.product.Product;
+import com.woowa.woowakit.domain.product.domain.product.ProductSales;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,17 +20,31 @@ import lombok.extern.slf4j.Slf4j;
 public class StockConsistencyProcessor {
 
 	private final StockRepository stockRepository;
+	private final ProductSalesRepository productSalesRepository;
 
 	@Transactional
 	public void run(final Product product) {
 		List<Stock> stocks = stockRepository.findAllByProductId(product.getId(), StockType.NORMAL);
 		Quantity difference = getTotalStockQuantity(stocks).subtract(product.getQuantity());
+		saveProductSales(product.getId(), difference);
 
 		for (Stock stock : stocks) {
 			Quantity removalQuantity = computeRemovalQuantity(difference, stock);
 			difference = difference.subtract(removalQuantity);
 			stock.subtractQuantity(removalQuantity);
 			removeStockIfEmpty(stock);
+		}
+	}
+
+	private void saveProductSales(final Long productId, final Quantity quantity) {
+		try {
+			productSalesRepository.save(ProductSales.builder()
+				.productId(productId)
+				.saleDate(LocalDate.now().minusDays(1))
+				.sale(Quantity.from(quantity.getValue()))
+				.build());
+		} catch (Exception e) {
+			log.warn("일일 판매량을 저장하는데 실패했습니다.", e);
 		}
 	}
 

--- a/src/main/java/com/woowa/woowakit/domain/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/dto/request/ProductSearchRequest.java
@@ -1,7 +1,11 @@
 package com.woowa.woowakit.domain.product.dto.request;
 
+import java.time.LocalDate;
+
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Null;
+
+import org.springframework.format.annotation.DateTimeFormat;
 
 import com.woowa.woowakit.domain.product.domain.product.ProductSearchCondition;
 
@@ -17,6 +21,8 @@ import lombok.Setter;
 @Setter
 public class ProductSearchRequest {
 
+	private static final int DEFAULT_PAGE_SIZE = 10;
+
 	@Null
 	private String productKeyword;
 
@@ -24,14 +30,22 @@ public class ProductSearchRequest {
 	private Long lastProductId;
 
 	@Min(value = 1, message = "최소 1개 이상의 상품을 조회해야합니다.")
-	private int pageSize;
+	private int pageSize = DEFAULT_PAGE_SIZE;
 
-	public static ProductSearchRequest of(final String productKeyword, final Long lastProductId, final int pageSize) {
-		return new ProductSearchRequest(productKeyword, lastProductId, pageSize);
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate saleDate = LocalDate.now().minusDays(1);
+
+	public static ProductSearchRequest of(
+		final String productKeyword,
+		final Long lastProductId,
+		final int pageSize,
+		final LocalDate saleDate
+	) {
+		return new ProductSearchRequest(productKeyword, lastProductId, pageSize, saleDate);
 	}
 
 	public ProductSearchCondition toProductSearchCondition() {
-		return ProductSearchCondition.of(productKeyword, lastProductId, pageSize);
+		return ProductSearchCondition.of(productKeyword, lastProductId, pageSize, saleDate);
 	}
 }
 

--- a/src/main/java/com/woowa/woowakit/domain/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/dto/request/ProductSearchRequest.java
@@ -3,7 +3,6 @@ package com.woowa.woowakit.domain.product.dto.request;
 import java.time.LocalDate;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.Null;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -23,10 +22,8 @@ public class ProductSearchRequest {
 
 	private static final int DEFAULT_PAGE_SIZE = 10;
 
-	@Null
 	private String productKeyword;
 
-	@Null
 	private Long lastProductId;
 
 	@Min(value = 1, message = "최소 1개 이상의 상품을 조회해야합니다.")

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -91,3 +91,14 @@ create table if not exists cart_items
     updated_at datetime not null,
     primary key(id)
 );
+
+create table if not exists product_sales
+(
+    id bigint auto_increment not null,
+    product_id bigint not null,
+    sale bigint not null,
+    sale_date   date not null,
+    created_at datetime not null,
+    updated_at datetime not null,
+    primary key(id)
+);

--- a/src/test/java/com/woowa/woowakit/domain/product/domain/stock/StockConsistencyProcessorTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/product/domain/stock/StockConsistencyProcessorTest.java
@@ -16,6 +16,7 @@ import com.woowa.woowakit.domain.product.domain.ProductSalesRepository;
 import com.woowa.woowakit.domain.product.domain.product.Product;
 import com.woowa.woowakit.domain.product.domain.product.ProductRepository;
 import com.woowa.woowakit.domain.product.domain.product.ProductSales;
+import com.woowa.woowakit.domain.product.domain.product.SaleQuantity;
 import com.woowa.woowakit.domain.product.fixture.ProductFixture;
 import com.woowa.woowakit.global.config.QuerydslTestConfig;
 
@@ -62,7 +63,7 @@ class StockConsistencyProcessorTest {
 		List<ProductSales> productSales = productSalesRepository.findByProductId(product.getId());
 		assertThat(productSales).hasSize(1)
 			.extracting("sale")
-			.contains(Quantity.from(25));
+			.contains(SaleQuantity.from(25));
 	}
 
 	private Stock createStock(Product product, LocalDate date, long quantity) {

--- a/src/test/java/com/woowa/woowakit/domain/product/domain/stock/StockConsistencyProcessorTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/product/domain/stock/StockConsistencyProcessorTest.java
@@ -12,13 +12,18 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import com.woowa.woowakit.domain.model.Quantity;
+import com.woowa.woowakit.domain.product.domain.ProductSalesRepository;
 import com.woowa.woowakit.domain.product.domain.product.Product;
 import com.woowa.woowakit.domain.product.domain.product.ProductRepository;
+import com.woowa.woowakit.domain.product.domain.product.ProductSales;
 import com.woowa.woowakit.domain.product.fixture.ProductFixture;
 import com.woowa.woowakit.global.config.QuerydslTestConfig;
 
 @DataJpaTest
-@Import({StockConsistencyProcessor.class, QuerydslTestConfig.class})
+@Import({
+	StockConsistencyProcessor.class,
+	QuerydslTestConfig.class
+})
 class StockConsistencyProcessorTest {
 
 	@Autowired
@@ -29,6 +34,9 @@ class StockConsistencyProcessorTest {
 
 	@Autowired
 	private StockConsistencyProcessor stockConsistencyProcessor;
+
+	@Autowired
+	private ProductSalesRepository productSalesRepository;
 
 	@Test
 	@DisplayName("상품 수량과 재고 테이블의 정합성을 맞춘다.")
@@ -50,6 +58,11 @@ class StockConsistencyProcessorTest {
 		assertThat(stocks).hasSize(2)
 			.extracting("quantity")
 			.contains(Quantity.from(5), Quantity.from(30));
+
+		List<ProductSales> productSales = productSalesRepository.findByProductId(product.getId());
+		assertThat(productSales).hasSize(1)
+			.extracting("sale")
+			.contains(Quantity.from(25));
 	}
 
 	private Stock createStock(Product product, LocalDate date, long quantity) {


### PR DESCRIPTION
## Description
기본적으로 상품을 조회할 때 일일 판매량 순으로 조회합니다.

## Changes
```java
        @Override
	public List<Product> searchProducts(final ProductSearchCondition condition) {
		return jpaQueryFactory.selectFrom(product)
			.leftJoin(productSales).on(product.id.eq(productSales.productId))
			.where(
				containsName(condition.getProductKeyword()),
				saleNow(condition.getSaleDate()),
				cursorId(condition.getLastProductId()))
			.limit(condition.getPageSize())
			.orderBy(productSales.sale.value.desc().nullsLast(), product.id.asc())
			.fetch();
	}
```

## Test Checklist

- 상품 판매량 순 조회
