### PR TITLE
feat: 상품을 일일 판매량 순으로 조회할 수 있다. 이름을 바탕으로 검색할 수 있다. (#98)

### DIFF
--- a/src/main/java/com/woowa/woowakit/domain/product/api/ProductController.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/api/ProductController.java
@@ -23,7 +23,7 @@ import com.woowa.woowakit.domain.product.dto.request.ProductSearchRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductStatusUpdateRequest;
 import com.woowa.woowakit.domain.product.dto.request.StockCreateRequest;
 import com.woowa.woowakit.domain.product.dto.response.ProductDetailResponse;
-import com.woowa.woowakit.domain.product.dto.response.ProductsResponse;
+import com.woowa.woowakit.domain.product.dto.response.ProductResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,11 +51,11 @@ public class ProductController {
 	}
 
 	@GetMapping
-	public ResponseEntity<List<ProductsResponse>> searchProducts(
+	public ResponseEntity<List<ProductResponse>> searchProducts(
 		@Valid @ModelAttribute final ProductSearchRequest request) {
 		log.info("productKeyword: {}, lastProductId: {} 상품 조회", request.getProductKeyword(),
 			request.getLastProductId());
-		final List<ProductsResponse> response = productService.searchProducts(request);
+		final List<ProductResponse> response = productService.searchProducts(request);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/woowa/woowakit/domain/product/api/ProductController.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/api/ProductController.java
@@ -23,6 +23,7 @@ import com.woowa.woowakit.domain.product.dto.request.ProductSearchRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductStatusUpdateRequest;
 import com.woowa.woowakit.domain.product.dto.request.StockCreateRequest;
 import com.woowa.woowakit.domain.product.dto.response.ProductDetailResponse;
+import com.woowa.woowakit.domain.product.dto.response.ProductsResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,11 +51,11 @@ public class ProductController {
 	}
 
 	@GetMapping
-	public ResponseEntity<List<ProductDetailResponse>> searchProducts(
+	public ResponseEntity<List<ProductsResponse>> searchProducts(
 		@Valid @ModelAttribute final ProductSearchRequest request) {
 		log.info("productKeyword: {}, lastProductId: {} 상품 조회", request.getProductKeyword(),
 			request.getLastProductId());
-		final List<ProductDetailResponse> response = productService.searchProducts(request);
+		final List<ProductsResponse> response = productService.searchProducts(request);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/woowa/woowakit/domain/product/application/ProductService.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/application/ProductService.java
@@ -2,10 +2,12 @@ package com.woowa.woowakit.domain.product.application;
 
 import com.woowa.woowakit.domain.product.domain.product.Product;
 import com.woowa.woowakit.domain.product.domain.product.ProductRepository;
+import com.woowa.woowakit.domain.product.domain.product.ProductSpecification;
 import com.woowa.woowakit.domain.product.dto.request.ProductCreateRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductSearchRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductStatusUpdateRequest;
 import com.woowa.woowakit.domain.product.dto.response.ProductDetailResponse;
+import com.woowa.woowakit.domain.product.dto.response.ProductsResponse;
 import com.woowa.woowakit.domain.product.exception.ProductNotExistException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,9 +36,9 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProductDetailResponse> searchProducts(final ProductSearchRequest productSearchRequest) {
-        final List<Product> products = productRepository.searchProducts(productSearchRequest.toProductSearchCondition());
-        return ProductDetailResponse.listOf(products);
+    public List<ProductsResponse> searchProducts(final ProductSearchRequest productSearchRequest) {
+        final List<ProductSpecification> productSpecifications = productRepository.searchProducts(productSearchRequest.toProductSearchCondition());
+        return ProductsResponse.listOf(productSpecifications);
     }
 
     @Transactional

--- a/src/main/java/com/woowa/woowakit/domain/product/application/ProductService.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/application/ProductService.java
@@ -7,7 +7,7 @@ import com.woowa.woowakit.domain.product.dto.request.ProductCreateRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductSearchRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductStatusUpdateRequest;
 import com.woowa.woowakit.domain.product.dto.response.ProductDetailResponse;
-import com.woowa.woowakit.domain.product.dto.response.ProductsResponse;
+import com.woowa.woowakit.domain.product.dto.response.ProductResponse;
 import com.woowa.woowakit.domain.product.exception.ProductNotExistException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,9 +36,10 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProductsResponse> searchProducts(final ProductSearchRequest productSearchRequest) {
-        final List<ProductSpecification> productSpecifications = productRepository.searchProducts(productSearchRequest.toProductSearchCondition());
-        return ProductsResponse.listOf(productSpecifications);
+    public List<ProductResponse> searchProducts(final ProductSearchRequest request) {
+        final List<ProductSpecification> productSpecifications = productRepository.searchProducts(
+            request.toProductSearchCondition());
+        return ProductResponse.listOf(productSpecifications);
     }
 
     @Transactional

--- a/src/main/java/com/woowa/woowakit/domain/product/dao/ProductRepositoryCustom.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/dao/ProductRepositoryCustom.java
@@ -2,10 +2,10 @@ package com.woowa.woowakit.domain.product.dao;
 
 import java.util.List;
 
-import com.woowa.woowakit.domain.product.domain.product.Product;
 import com.woowa.woowakit.domain.product.domain.product.ProductSearchCondition;
+import com.woowa.woowakit.domain.product.domain.product.ProductSpecification;
 
 public interface ProductRepositoryCustom {
 
-	List<Product> searchProducts(ProductSearchCondition condition);
+	List<ProductSpecification> searchProducts(ProductSearchCondition condition);
 }

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSearchCondition.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSearchCondition.java
@@ -14,6 +14,8 @@ public class ProductSearchCondition {
 
 	private Long lastProductId;
 
+	private Long lastProductSale;
+
 	private int pageSize;
 
 	private LocalDate saleDate;
@@ -21,9 +23,10 @@ public class ProductSearchCondition {
 	public static ProductSearchCondition of(
 		final String productKeyword,
 		final Long lastProductId,
+		final Long lastProductSale,
 		final int pageSize,
 		final LocalDate saleDate
 	) {
-		return new ProductSearchCondition(productKeyword, lastProductId, pageSize, saleDate);
+		return new ProductSearchCondition(productKeyword, lastProductId, lastProductSale, pageSize, saleDate);
 	}
 }

--- a/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSpecification.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/domain/product/ProductSpecification.java
@@ -1,0 +1,16 @@
+package com.woowa.woowakit.domain.product.domain.product;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ProductSpecification {
+
+	private Product product;
+	private long productSale;
+
+}

--- a/src/main/java/com/woowa/woowakit/domain/product/dto/request/ProductSearchRequest.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/dto/request/ProductSearchRequest.java
@@ -26,6 +26,8 @@ public class ProductSearchRequest {
 
 	private Long lastProductId;
 
+	private Long lastProductSale;
+
 	@Min(value = 1, message = "최소 1개 이상의 상품을 조회해야합니다.")
 	private int pageSize = DEFAULT_PAGE_SIZE;
 
@@ -35,14 +37,15 @@ public class ProductSearchRequest {
 	public static ProductSearchRequest of(
 		final String productKeyword,
 		final Long lastProductId,
+		final Long lastProductSale,
 		final int pageSize,
 		final LocalDate saleDate
 	) {
-		return new ProductSearchRequest(productKeyword, lastProductId, pageSize, saleDate);
+		return new ProductSearchRequest(productKeyword, lastProductId, lastProductSale, pageSize, saleDate);
 	}
 
 	public ProductSearchCondition toProductSearchCondition() {
-		return ProductSearchCondition.of(productKeyword, lastProductId, pageSize, saleDate);
+		return ProductSearchCondition.of(productKeyword, lastProductId, lastProductSale, pageSize, saleDate);
 	}
 }
 

--- a/src/main/java/com/woowa/woowakit/domain/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/dto/response/ProductDetailResponse.java
@@ -1,9 +1,7 @@
 package com.woowa.woowakit.domain.product.dto.response;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.woowa.woowakit.domain.product.domain.product.Product;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,44 +11,38 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ProductDetailResponse {
 
-    private Long id;
-    private String name;
-    private Long price;
-    private String imageUrl;
-    private String status;
-    private long quantity;
+	private Long id;
+	private String name;
+	private Long price;
+	private String imageUrl;
+	private String status;
+	private long quantity;
 
-    @Builder
-    private ProductDetailResponse(
-        final Long id,
-        final String name,
-        final Long price,
-        final String imageUrl,
-        final String status,
-        final long quantity
-    ) {
-        this.id = id;
-        this.name = name;
-        this.price = price;
-        this.imageUrl = imageUrl;
-        this.status = status;
-        this.quantity = quantity;
-    }
+	@Builder
+	private ProductDetailResponse(
+		final Long id,
+		final String name,
+		final Long price,
+		final String imageUrl,
+		final String status,
+		final long quantity
+	) {
+		this.id = id;
+		this.name = name;
+		this.price = price;
+		this.imageUrl = imageUrl;
+		this.status = status;
+		this.quantity = quantity;
+	}
 
-    public static ProductDetailResponse from(final Product product) {
-        return ProductDetailResponse.builder()
-            .id(product.getId())
-            .name(product.getName().getName())
-            .price(product.getPrice().getPrice().getValue())
-            .imageUrl(product.getImageUrl().getPath())
-            .quantity(product.getQuantity().getValue())
-            .status(product.getStatus().toString())
-            .build();
-    }
-
-    public static List<ProductDetailResponse> listOf(final List<Product> products) {
-        return products.stream()
-            .map(ProductDetailResponse::from)
-            .collect(Collectors.toUnmodifiableList());
-    }
+	public static ProductDetailResponse from(final Product product) {
+		return ProductDetailResponse.builder()
+			.id(product.getId())
+			.name(product.getName().getName())
+			.price(product.getPrice().getPrice().getValue())
+			.imageUrl(product.getImageUrl().getPath())
+			.quantity(product.getQuantity().getValue())
+			.status(product.getStatus().name())
+			.build();
+	}
 }

--- a/src/main/java/com/woowa/woowakit/domain/product/dto/response/ProductResponse.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/dto/response/ProductResponse.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class ProductsResponse {
+public class ProductResponse {
 
     private Long id;
     private String name;
@@ -23,7 +23,7 @@ public class ProductsResponse {
     private long productSale;
 
     @Builder
-    private ProductsResponse(
+    private ProductResponse(
         final Long id,
         final String name,
         final Long price,
@@ -41,8 +41,8 @@ public class ProductsResponse {
         this.productSale = productSale;
     }
 
-    public static ProductsResponse from(final ProductSpecification productSpecification) {
-        return ProductsResponse.builder()
+    public static ProductResponse from(final ProductSpecification productSpecification) {
+        return ProductResponse.builder()
             .id(productSpecification.getProduct().getId())
             .name(productSpecification.getProduct().getName().getName())
             .price(productSpecification.getProduct().getPrice().getPrice().getValue())
@@ -53,9 +53,9 @@ public class ProductsResponse {
             .build();
     }
 
-    public static List<ProductsResponse> listOf(final List<ProductSpecification> productSpecifications) {
+    public static List<ProductResponse> listOf(final List<ProductSpecification> productSpecifications) {
         return productSpecifications.stream()
-            .map(ProductsResponse::from)
+            .map(ProductResponse::from)
             .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/main/java/com/woowa/woowakit/domain/product/dto/response/ProductsResponse.java
+++ b/src/main/java/com/woowa/woowakit/domain/product/dto/response/ProductsResponse.java
@@ -1,0 +1,61 @@
+package com.woowa.woowakit.domain.product.dto.response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.woowa.woowakit.domain.product.domain.product.ProductSpecification;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ProductsResponse {
+
+    private Long id;
+    private String name;
+    private Long price;
+    private String imageUrl;
+    private String status;
+    private long quantity;
+    private long productSale;
+
+    @Builder
+    private ProductsResponse(
+        final Long id,
+        final String name,
+        final Long price,
+        final String imageUrl,
+        final String status,
+        final long quantity,
+        final long productSale
+    ) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.status = status;
+        this.quantity = quantity;
+        this.productSale = productSale;
+    }
+
+    public static ProductsResponse from(final ProductSpecification productSpecification) {
+        return ProductsResponse.builder()
+            .id(productSpecification.getProduct().getId())
+            .name(productSpecification.getProduct().getName().getName())
+            .price(productSpecification.getProduct().getPrice().getPrice().getValue())
+            .imageUrl(productSpecification.getProduct().getImageUrl().getPath())
+            .quantity(productSpecification.getProduct().getQuantity().getValue())
+            .status(productSpecification.getProduct().getStatus().name())
+            .productSale(productSpecification.getProductSale())
+            .build();
+    }
+
+    public static List<ProductsResponse> listOf(final List<ProductSpecification> productSpecifications) {
+        return productSpecifications.stream()
+            .map(ProductsResponse::from)
+            .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/src/test/java/com/woowa/woowakit/domain/product/dao/ProductRepositoryTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/product/dao/ProductRepositoryTest.java
@@ -17,6 +17,7 @@ import com.woowa.woowakit.domain.product.domain.product.ProductName;
 import com.woowa.woowakit.domain.product.domain.product.ProductRepository;
 import com.woowa.woowakit.domain.product.domain.product.ProductSales;
 import com.woowa.woowakit.domain.product.domain.product.ProductSearchCondition;
+import com.woowa.woowakit.domain.product.domain.product.ProductSpecification;
 import com.woowa.woowakit.domain.product.fixture.ProductFixture;
 import com.woowa.woowakit.global.config.QuerydslTestConfig;
 
@@ -44,14 +45,14 @@ class ProductRepositoryTest {
 		productRepository.saveAll(List.of(product1, product2, product3, product4, product5));
 
 		// when
-		ProductSearchCondition productSearchCondition = ProductSearchCondition.of("1", null, 5, LocalDate.now());
-		List<Product> result = productRepository.searchProducts(productSearchCondition);
+		ProductSearchCondition productSearchCondition = ProductSearchCondition.of("1", null, null, 5, LocalDate.now());
+		List<ProductSpecification> result = productRepository.searchProducts(productSearchCondition);
 
 		// then
 		Assertions.assertThat(result).hasSize(3);
-		Assertions.assertThat(result.get(0)).extracting(Product::getId).isEqualTo(product1.getId());
-		Assertions.assertThat(result.get(1)).extracting(Product::getId).isEqualTo(product4.getId());
-		Assertions.assertThat(result.get(2)).extracting(Product::getId).isEqualTo(product5.getId());
+		Assertions.assertThat(result.get(0)).extracting(ProductSpecification::getProduct).extracting(Product::getId).isEqualTo(product1.getId());
+		Assertions.assertThat(result.get(1)).extracting(ProductSpecification::getProduct).extracting(Product::getId).isEqualTo(product4.getId());
+		Assertions.assertThat(result.get(2)).extracting(ProductSpecification::getProduct).extracting(Product::getId).isEqualTo(product5.getId());
 	}
 
 	@Test
@@ -67,14 +68,14 @@ class ProductRepositoryTest {
 		productRepository.saveAll(List.of(product1, product2, product3, product4, product5));
 
 		// when
-		ProductSearchCondition productSearchCondition = ProductSearchCondition.of("테스트", product2.getId(), 2,
+		ProductSearchCondition productSearchCondition = ProductSearchCondition.of("테스트", product2.getId(), null, 2,
 			LocalDate.now());
-		List<Product> result = productRepository.searchProducts(productSearchCondition);
+		List<ProductSpecification> result = productRepository.searchProducts(productSearchCondition);
 
 		// then
 		Assertions.assertThat(result).hasSize(2);
-		Assertions.assertThat(result.get(0)).extracting(Product::getId).isEqualTo(product3.getId());
-		Assertions.assertThat(result.get(1)).extracting(Product::getId).isEqualTo(product4.getId());
+		Assertions.assertThat(result.get(0)).extracting(ProductSpecification::getProduct).extracting(Product::getId).isEqualTo(product3.getId());
+		Assertions.assertThat(result.get(1)).extracting(ProductSpecification::getProduct).extracting(Product::getId).isEqualTo(product4.getId());
 	}
 
 	@Test
@@ -92,23 +93,50 @@ class ProductRepositoryTest {
 		Product productD = productRepository.save(ProductFixture.anProduct()
 			.name(ProductName.from("productD"))
 			.build());
+		Product productE = productRepository.save(ProductFixture.anProduct()
+			.name(ProductName.from("productE"))
+			.build());
+		Product productF = productRepository.save(ProductFixture.anProduct()
+			.name(ProductName.from("productF"))
+			.build());
+		Product productG = productRepository.save(ProductFixture.anProduct()
+			.name(ProductName.from("productG"))
+			.build());
+		Product productH = productRepository.save(ProductFixture.anProduct()
+			.name(ProductName.from("productH"))
+			.build());
+		Product productI = productRepository.save(ProductFixture.anProduct()
+			.name(ProductName.from("productI"))
+			.build());
+		Product productJ = productRepository.save(ProductFixture.anProduct()
+			.name(ProductName.from("productJ"))
+			.build());
 
-		productSalesRepository.save(createProductSale(productA, 10, LocalDate.of(2023, 8, 25)));
-		productSalesRepository.save(createProductSale(productB, 20, LocalDate.of(2023, 8, 25)));
+
+		productSalesRepository.save(createProductSale(productA, 50, LocalDate.of(2023, 8, 25)));
+		productSalesRepository.save(createProductSale(productB, 60, LocalDate.of(2023, 8, 25)));
 		productSalesRepository.save(createProductSale(productC, 30, LocalDate.of(2023, 8, 25)));
+		productSalesRepository.save(createProductSale(productD, 30, LocalDate.of(2023, 8, 25)));
+		productSalesRepository.save(createProductSale(productE, 30, LocalDate.of(2023, 8, 25)));
+		productSalesRepository.save(createProductSale(productF, 30, LocalDate.of(2023, 8, 25)));
+		productSalesRepository.save(createProductSale(productG, 30, LocalDate.of(2023, 8, 25)));
+		productSalesRepository.save(createProductSale(productH, 30, LocalDate.of(2023, 8, 25)));
+		productSalesRepository.save(createProductSale(productI, 30, LocalDate.of(2023, 8, 25)));
+		productSalesRepository.save(createProductSale(productJ, 30, LocalDate.of(2023, 8, 25)));
 
-		ProductSearchCondition condition = ProductSearchCondition.of(null, 0L, 10, LocalDate.of(2023, 8, 25));
-		List<Product> products = productRepository.searchProducts(condition);
+		ProductSearchCondition condition = ProductSearchCondition.of(null, productD.getId(), 30L, 4, LocalDate.of(2023, 8, 25));
+		List<ProductSpecification> products = productRepository.searchProducts(condition);
 		Assertions.assertThat(products).hasSize(4)
+			.extracting("product")
 			.extracting("name")
 			.contains(
-				ProductName.from("productC"),
-				ProductName.from("productB"),
-				ProductName.from("productA"),
-				ProductName.from("productD"));
+				ProductName.from("productE"),
+				ProductName.from("productF"),
+				ProductName.from("productG"),
+				ProductName.from("productH"));
 	}
 
-	private ProductSales createProductSale(Product productA, long quantity, LocalDate saleDate) {
+	private ProductSales createProductSale(final Product productA, final long quantity, final LocalDate saleDate) {
 		return ProductSales.builder()
 			.productId(productA.getId())
 			.sale(Quantity.from(quantity))

--- a/src/test/java/com/woowa/woowakit/domain/product/dao/ProductRepositoryTest.java
+++ b/src/test/java/com/woowa/woowakit/domain/product/dao/ProductRepositoryTest.java
@@ -127,8 +127,8 @@ class ProductRepositoryTest {
 		ProductSearchCondition condition = ProductSearchCondition.of(null, productD.getId(), 30L, 4, LocalDate.of(2023, 8, 25));
 		List<ProductSpecification> products = productRepository.searchProducts(condition);
 		Assertions.assertThat(products).hasSize(4)
-			.extracting("product")
-			.extracting("name")
+			.extracting(ProductSpecification::getProduct)
+			.extracting(Product::getName)
 			.contains(
 				ProductName.from("productE"),
 				ProductName.from("productF"),

--- a/src/test/java/integration/helper/ProductHelper.java
+++ b/src/test/java/integration/helper/ProductHelper.java
@@ -6,7 +6,7 @@ import com.woowa.woowakit.domain.product.domain.product.ProductStatus;
 import com.woowa.woowakit.domain.product.dto.request.ProductCreateRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductStatusUpdateRequest;
 import com.woowa.woowakit.domain.product.dto.request.StockCreateRequest;
-import com.woowa.woowakit.domain.product.dto.response.ProductsResponse;
+import com.woowa.woowakit.domain.product.dto.response.ProductResponse;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -86,7 +86,7 @@ public class ProductHelper {
 		return getIdFrom(location);
 	}
 
-	public static ProductsResponse getProductDetail(Long productId) {
-		return CommonRestAssuredUtils.get("/products/" + productId).as(ProductsResponse.class);
+	public static ProductResponse getProductDetail(Long productId) {
+		return CommonRestAssuredUtils.get("/products/" + productId).as(ProductResponse.class);
 	}
 }

--- a/src/test/java/integration/helper/ProductHelper.java
+++ b/src/test/java/integration/helper/ProductHelper.java
@@ -6,7 +6,7 @@ import com.woowa.woowakit.domain.product.domain.product.ProductStatus;
 import com.woowa.woowakit.domain.product.dto.request.ProductCreateRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductStatusUpdateRequest;
 import com.woowa.woowakit.domain.product.dto.request.StockCreateRequest;
-import com.woowa.woowakit.domain.product.dto.response.ProductDetailResponse;
+import com.woowa.woowakit.domain.product.dto.response.ProductsResponse;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -86,7 +86,7 @@ public class ProductHelper {
 		return getIdFrom(location);
 	}
 
-	public static ProductDetailResponse getProductDetail(Long productId) {
-		return CommonRestAssuredUtils.get("/products/" + productId).as(ProductDetailResponse.class);
+	public static ProductsResponse getProductDetail(Long productId) {
+		return CommonRestAssuredUtils.get("/products/" + productId).as(ProductsResponse.class);
 	}
 }

--- a/src/test/java/integration/product/ProductIntegrationTest.java
+++ b/src/test/java/integration/product/ProductIntegrationTest.java
@@ -14,7 +14,7 @@ import com.woowa.woowakit.domain.product.domain.product.ProductStatus;
 import com.woowa.woowakit.domain.product.dto.request.ProductCreateRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductStatusUpdateRequest;
 import com.woowa.woowakit.domain.product.dto.request.StockCreateRequest;
-import com.woowa.woowakit.domain.product.dto.response.ProductsResponse;
+import com.woowa.woowakit.domain.product.dto.response.ProductResponse;
 
 import integration.IntegrationTest;
 import integration.helper.CommonRestAssuredUtils;
@@ -53,7 +53,7 @@ class ProductIntegrationTest extends IntegrationTest {
 
 		// then
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-		ProductsResponse detailResponse = response.as(ProductsResponse.class);
+		ProductResponse detailResponse = response.as(ProductResponse.class);
 		assertThat(detailResponse).extracting("quantity").isEqualTo(0L);
 		assertThat(detailResponse).extracting("imageUrl").isEqualTo("testImage");
 		assertThat(detailResponse).extracting("status").isEqualTo("PRE_REGISTRATION");
@@ -77,7 +77,7 @@ class ProductIntegrationTest extends IntegrationTest {
 
 		// then
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-		List<ProductsResponse> responses = response.as(ArrayList.class);
+		List<ProductResponse> responses = response.as(ArrayList.class);
 		assertThat(responses).hasSize(2);
 	}
 
@@ -96,7 +96,7 @@ class ProductIntegrationTest extends IntegrationTest {
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 		assertThat(response.header("Location")).matches("^/products/[0-9]+/stocks/[0-9]+$");
 
-		ProductsResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductsResponse.class);
+		ProductResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductResponse.class);
 		assertThat(productResponse).extracting("quantity").isEqualTo(5L);
 	}
 
@@ -119,7 +119,7 @@ class ProductIntegrationTest extends IntegrationTest {
 
 		//then
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-		ProductsResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductsResponse.class);
+		ProductResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductResponse.class);
 		assertThat(productResponse).extracting("status").isEqualTo("IN_STOCK");
 	}
 
@@ -146,7 +146,7 @@ class ProductIntegrationTest extends IntegrationTest {
 
 		//then
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-		ProductsResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductsResponse.class);
+		ProductResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductResponse.class);
 		assertThat(productResponse).extracting("status").isEqualTo("STOPPED");
 	}
 

--- a/src/test/java/integration/product/ProductIntegrationTest.java
+++ b/src/test/java/integration/product/ProductIntegrationTest.java
@@ -14,7 +14,7 @@ import com.woowa.woowakit.domain.product.domain.product.ProductStatus;
 import com.woowa.woowakit.domain.product.dto.request.ProductCreateRequest;
 import com.woowa.woowakit.domain.product.dto.request.ProductStatusUpdateRequest;
 import com.woowa.woowakit.domain.product.dto.request.StockCreateRequest;
-import com.woowa.woowakit.domain.product.dto.response.ProductDetailResponse;
+import com.woowa.woowakit.domain.product.dto.response.ProductsResponse;
 
 import integration.IntegrationTest;
 import integration.helper.CommonRestAssuredUtils;
@@ -53,7 +53,7 @@ class ProductIntegrationTest extends IntegrationTest {
 
 		// then
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-		ProductDetailResponse detailResponse = response.as(ProductDetailResponse.class);
+		ProductsResponse detailResponse = response.as(ProductsResponse.class);
 		assertThat(detailResponse).extracting("quantity").isEqualTo(0L);
 		assertThat(detailResponse).extracting("imageUrl").isEqualTo("testImage");
 		assertThat(detailResponse).extracting("status").isEqualTo("PRE_REGISTRATION");
@@ -77,7 +77,7 @@ class ProductIntegrationTest extends IntegrationTest {
 
 		// then
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-		List<ProductDetailResponse> responses = response.as(ArrayList.class);
+		List<ProductsResponse> responses = response.as(ArrayList.class);
 		assertThat(responses).hasSize(2);
 	}
 
@@ -96,7 +96,7 @@ class ProductIntegrationTest extends IntegrationTest {
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 		assertThat(response.header("Location")).matches("^/products/[0-9]+/stocks/[0-9]+$");
 
-		ProductDetailResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductDetailResponse.class);
+		ProductsResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductsResponse.class);
 		assertThat(productResponse).extracting("quantity").isEqualTo(5L);
 	}
 
@@ -119,7 +119,7 @@ class ProductIntegrationTest extends IntegrationTest {
 
 		//then
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-		ProductDetailResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductDetailResponse.class);
+		ProductsResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductsResponse.class);
 		assertThat(productResponse).extracting("status").isEqualTo("IN_STOCK");
 	}
 
@@ -146,7 +146,7 @@ class ProductIntegrationTest extends IntegrationTest {
 
 		//then
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-		ProductDetailResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductDetailResponse.class);
+		ProductsResponse productResponse = CommonRestAssuredUtils.get(location).as(ProductsResponse.class);
 		assertThat(productResponse).extracting("status").isEqualTo("STOPPED");
 	}
 


### PR DESCRIPTION
안녕하세요 불타는 금요일 코딩으로 불타는 좋은 하루입니다.
## Description
이번에 Product 검색을 커서 방식으로 전환했습니다.
Product의 일일 판매량은 같은 값일 경우가 있어 이 값만으로 커서 방식을 채택하게 되면 같은 판매량의 데이터가 다음 페이지에서 보이지 않는 경우가 발생할 수 있습니다. 이를 위해 일일 판매량과 Product의 pk 값으로 커서 방식을 채택했습니다.
그리고 현재 프론트에서 상품의 일일 판매량 값을 알 수 없어 프론트에 상품 리스트를 응답할 때 일일 판매량을 던져주는 방향으로 개발하였습니다.

아직 성능 측정을 진행하지 않아 커서 방식이 어느정도 성능을 보장할지는 잘 모르지만 아마 인덱스를 잘 걸어주면 좋은 성능을 보장할것이라 생각합니다. 다음 작업이 아마 인덱스 추가하는 작업일거같은데 이 때 성능 측정 후 인덱스를 걸어 어느정도 성능 향상이 발생하는지 확인하도록 하겠습니다.

그리고 Product와 ProductSales 사이가 OneToMany 연관 관계를 물고 있어 추후 일일 판매량에 unique 제약을 두어 일일 판매량이 where에서 주어진 경우 OneToOne 매핑이 되도록 데이터베이스 수정이 필요합니다.

궁금한 사항이나 이상한 점 있으시면 리뷰 남겨주세요~

## Changes
커밋로그 확인해주세요~

## Test Checklist
기존 테스트에 값만 변경되었습니다.
추가한 테스트 1개 있습니다.
productRepositoryTest
- 상품 판매량 순 조회

